### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/AutoHotkey/Home/auto-correct.ahk
+++ b/AutoHotkey/Home/auto-correct.ahk
@@ -601,7 +601,7 @@ return  ; This makes the above hotstrings do nothing so that they override the i
 
 ::avengence::a vengeance
 ::adbandon::abandon
-::abandonned::abandoned
+::abandoned::abandoned
 ::aberation::aberration
 ::aborigene::aborigine
 ::abortificant::abortifacient


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            